### PR TITLE
Remove non-POSIX functions and be more tolerant with sethostname(3) prototype.

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Example:
 
     posix.syslog('info', 'hello, world!');
 
-## hostname/domainname
+## hostname
 
 ### posix.gethostname()
 
@@ -308,24 +308,12 @@ Example:
 
     posix.sethostname('beefheart');
 
-### posix.getdomainname()
-
-Returns the domain name of the operating system.
-
-### posix.setdomainname(domainname)
-
-Sets the domain name of the operating system.
-
-Example:
-
-    posix.setdomainname('magicband.edu');
-
 ## Credits
 
 * Some of the documentation strings stolen from Linux man pages.
 * `posix.seteuid` etc. implementation is based on Node core project `SetUid`
 * Fixes: Dan Bornstein
-* `gethostname`, `sethostname`, `getdomainname`, `setdomainname`: Igor Pashev
+* `gethostname`, `sethostname`: Igor Pashev
 
 ## LICENSE
 

--- a/lib/posix/index.js
+++ b/lib/posix/index.js
@@ -99,6 +99,4 @@ module.exports = {
 
     gethostname: posix.gethostname,
     sethostname: posix.sethostname,
-    getdomainname: posix.getdomainname,
-    setdomainname: posix.setdomainname,
 };

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
         "posix", "rlimit", "getrlimit", "setrlimit", "ulimit", "setuid",
         "setgid", "seteuid", "setegid", "chroot", "setreuid", "setregid",
         "getpgrp", "setsid", "setpgid", "getpwnam", "getgrnam", "uid", "gid",
-        "syslog", "setlogmask", "gethostname", "sethostname",
-        "getdomainname", "setdomainname"
+        "syslog", "setlogmask", "gethostname", "sethostname"
     ],
     "homepage": "http://github.com/melor/node-posix",
     "repository" : {

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -510,26 +510,6 @@ static Handle<Value> node_gethostname(const Arguments& args) {
     return scope.Close(String::New(hostname));
 }
 
-static Handle<Value> node_getdomainname(const Arguments& args) {
-    HandleScope scope;
-
-    if(args.Length() != 0) {
-        return EXCEPTION("getdomainname: takes no arguments");
-    }
-#ifndef DOMAIN_NAME_MAX
-# define DOMAIN_NAME_MAX 64
-#endif
-
-    char domainname[DOMAIN_NAME_MAX];
-
-    int rc = getdomainname(domainname, DOMAIN_NAME_MAX);
-    if (rc != 0) {
-        return ThrowException(ErrnoException(errno, "getdomainname"));
-    }
-
-    return scope.Close(String::New(domainname));
-}
-
 static Handle<Value> node_sethostname(const Arguments& args) {
     HandleScope scope;
 
@@ -542,38 +522,14 @@ static Handle<Value> node_sethostname(const Arguments& args) {
     }
 
     String::Utf8Value str(args[0]);
-    const char * hostname = *str;
 
-    int rc = sethostname(hostname, str.length());
+    int rc = sethostname(*str, str.length());
     if (rc != 0) {
         return ThrowException(ErrnoException(errno, "sethostname"));
     }
 
     return scope.Close(Undefined());
 }
-
-static Handle<Value> node_setdomainname(const Arguments& args) {
-    HandleScope scope;
-
-    if (args.Length() != 1) {
-        return EXCEPTION("setdomainname: takes exactly 1 argument");
-    }
-
-    if (!args[0]->IsString()) {
-        return EXCEPTION("setdomainname: first argument must be a string");
-    }
-
-    String::Utf8Value str(args[0]);
-    const char * domainname = *str;
-
-    int rc = setdomainname(domainname, str.length());
-    if (rc != 0) {
-        return ThrowException(ErrnoException(errno, "setdomainname"));
-    }
-
-    return scope.Close(Undefined());
-}
-
 
 extern "C" void init(Handle<Object> target)
 {
@@ -599,9 +555,7 @@ extern "C" void init(Handle<Object> target)
     NODE_SET_METHOD(target, "update_syslog_constants",
                     node_update_syslog_constants);
     NODE_SET_METHOD(target, "gethostname", node_gethostname);
-    NODE_SET_METHOD(target, "getdomainname", node_getdomainname);
     NODE_SET_METHOD(target, "sethostname", node_sethostname);
-    NODE_SET_METHOD(target, "setdomainname", node_setdomainname);
 }
 
 NODE_MODULE(posix, init);

--- a/test/unit/test-getdomainname.js
+++ b/test/unit/test-getdomainname.js
@@ -1,6 +1,0 @@
-var assert = require('assert');
-var posix = require('../../lib/posix');
-
-var domainname = posix.getdomainname();
-console.log('domainname: ' + domainname);
-assert.ok(typeof(domainname) === 'string');


### PR DESCRIPTION
Remove getdomainname and setdomainname as they are not POSIX.

Some system implement sethostname(char *...) instead of const char *.
Since, a passing in const char \* will cause an error on those platforms
and passing a char \* will not cause an error on any platform, prefer the
latter.
