### PR TITLE
Use 'bindings' modules to load posix.node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+node_modules/
 *~
 .lock-wscript
 *.log

--- a/lib/posix/index.js
+++ b/lib/posix/index.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var posix = require(path.join(__dirname, '/../../build/Release/posix.node'));
+var posix = require('bindings')('posix.node');
 
 var syslog_constants = {};
 posix.update_syslog_constants(syslog_constants);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "author" : "Mika Eloranta <mel@ohmu.fi>",
     "main" : "./lib/posix",
     "dependencies" : {
+        "bindings" : "~1.1.0"
     },
     "scripts" : {
         "test" : "make test"


### PR DESCRIPTION
Depending on how gyp and node are configured, they can build and try to
load native modules in a number of different locations. The current
hardcoded 'Release' dir is not always correct resulting in exceptions
while loading. In particular, it doesn't handle the case where node is
built in 'Debug' mode. The 'bindings' module handles the common cases of
this issue.
