### PR TITLE
Add "nproc" support to getrlimit/setrlimit (for supported OSes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ signal.
 `'nofile'` (RLIMIT_NOFILE) Specifies a value one greater than the maximum file
 descriptor number that can be opened by this process.
 
+`'nproc'` (RLIMIT_NPROC) The maximum number of processes (or, more precisely on Linux,
+threads) that can be created by this process. *(Note: Only Linux, OS X, and BSDs support the 'nproc' resource limit. An error will be raised on unsupported platforms.)*
+
 `'stack'` (RLIMIT_STACK) The maximum size of the process stack, in bytes. Upon
 reaching this limit, a SIGSEGV signal is generated.
 

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -106,6 +106,9 @@ static const name_to_int_t rlimit_name_to_res[] = {
   { "data", RLIMIT_DATA },
   { "fsize", RLIMIT_FSIZE },
   { "nofile", RLIMIT_NOFILE },
+  #ifdef RLIMIT_NPROC
+  { "nproc", RLIMIT_NPROC },
+  #endif
   { "stack", RLIMIT_STACK },
   { "as", RLIMIT_AS },
   { 0, 0 }

--- a/test/unit/test-getrlimit.js
+++ b/test/unit/test-getrlimit.js
@@ -7,9 +7,18 @@ var limits = [
     "data",
     "fsize",
     "nofile",
+    "nproc",
     "stack",
     "as"
 ];
+
+var unsupportedLimits = [];
+
+if(['linux', 'darwin', 'freebsd'].indexOf(process.platform) !== -1) {
+    limits.push('nproc');
+} else {
+    unsupportedLimits.push('nproc');
+}
 
 // getrlimit: invalid input args
 try {
@@ -36,4 +45,12 @@ for(var i in limits) {
     console.log("getrlimit " + limits[i] + ": " + JSON.stringify(limit));
     assert.equal(true, typeof limit.soft == 'number' || limit.soft === null);
     assert.equal(true, typeof limit.hard == 'number' || limit.hard === null);
+}
+
+for(i in unsupportedLimits) {
+    try {
+        posix.getrlimit(unsupportedLimits[i]);
+        assert.ok(false);
+    }
+    catch(e) { }
 }

--- a/test/unit/test-setrlimit.js
+++ b/test/unit/test-setrlimit.js
@@ -7,9 +7,18 @@ var limits = [
     "data",
     "fsize",
     "nofile",
+    "nproc",
     "stack",
     "as"
 ];
+
+var unsupportedLimits = [];
+
+if(['linux', 'darwin', 'freebsd'].indexOf(process.platform) !== -1) {
+    limits.push('nproc');
+} else {
+    unsupportedLimits.push('nproc');
+}
 
 // setrlimit: invalid input args
 try {
@@ -60,4 +69,12 @@ for(var i in limits) {
         console.log(limits[i] + " was: " + JSON.stringify(limit));
         console.log(limits[i] + " now: " + JSON.stringify(limit2));
     }
+}
+
+for(i in unsupportedLimits) {
+    try {
+        posix.setrlimit(unsupportedLimits[i], {soft: 100});
+        assert.ok(false);
+    }
+    catch(e) { }
 }


### PR DESCRIPTION
This picks up on @fbrusch's pull request from #22. It adds the `nproc` support, but is `#ifdef`ed like you suggested, and I updated the documentation in the README.

I also added tests that I believe should work across platforms to ensure that it's supported on the expected platforms but still raises errors on unsupported platforms. I don't have access to a Solaris or Windows box to totally verify these tests across platforms, but from what I gather it's only supported on Linux and BSDs (and they pass locally on a Linux and OS X box), so I'm hoping the test logic for platform support is correct.
