### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/src/posix.cc
+++ b/src/posix.cc
@@ -140,7 +140,9 @@ static const name_to_int_t rlimit_name_to_res[] = {
   { "nproc", RLIMIT_NPROC },
     #endif
   { "stack", RLIMIT_STACK },
+  #ifdef RLIMIT_AS
   { "as", RLIMIT_AS },
+  #endif
   { 0, 0 }
 };
 


### PR DESCRIPTION
OpenBSD does not have RLIMIT_AS. See the BUGS section of the man page
for setrlimit(2) here: http://man.openbsd.org/setrlimit.2#BUGS