### PR TITLE
Throw errors not strings

### DIFF
--- a/lib/posix/index.js
+++ b/lib/posix/index.js
@@ -18,7 +18,7 @@ function load_extension() {
             }
         }
     }
-    throw "unable to load the node-posix extension module";
+    throw new Error("unable to load the node-posix extension module");
 }
 
 var posix = load_extension();
@@ -28,7 +28,7 @@ posix.update_syslog_constants(syslog_constants);
 
 function syslog_const(value) {
     if (syslog_constants[value] === undefined) {
-        throw "invalid syslog constant value: " + value;
+        throw new Error("invalid syslog constant value: " + value);
     }
 
     return syslog_constants[value];


### PR DESCRIPTION
If we throw instances of `String`, catching code has no way of knowing where the string was thrown from.

This PR changes the code to throw instances of `Error` instead so there is a `.stack` property available to show to the developer.